### PR TITLE
Optimize pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run linting & unittest
+        if: matrix.os == 'ubuntu-latest'
         run: make ci
 
       - name: Build package


### PR DESCRIPTION
- Use only golang 1.17 for test & lint pipeline.
- Run `make ci` only on Ubuntu