### PR TITLE
fix: remove Dependency Dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     ":semanticCommitTypeAll(chore)",
     ":gitSignOff"
   ],
+  "dependencyDashboard": false,
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],


### PR DESCRIPTION
fixes #30 

Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

The dashboard is not useful, on most project have it disabled.