### PR TITLE
docs: add go report card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![SIT](https://img.shields.io/badge/SIT-awesome-blueviolet.svg)](https://jobs.schwarz)
 [![CI](https://github.com/SchwarzIT/go-template/actions/workflows/main.yml/badge.svg)](https://github.com/SchwarzIT/go-template/actions/workflows/main.yml)
 [![Semgrep](https://github.com/SchwarzIT/go-template/actions/workflows/semgrep.yml/badge.svg)](https://github.com/SchwarzIT/go-template/actions/workflows/semgrep.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/SchwarzIT/go-template)](https://goreportcard.com/report/github.com/SchwarzIT/go-template)
 
 `go/template` provides a **blueprint** for production-ready Go project layouts.
 


### PR DESCRIPTION
Add a new badge from goreportcard.com
[![Go Report Card](https://goreportcard.com/badge/github.com/SchwarzIT/go-template)](https://goreportcard.com/report/github.com/SchwarzIT/go-template)

Signed-off-by: Steffen Exler <Steffen.Exler@mail.schwarz>