### PR TITLE
docs: remove space after badge

### DIFF
--- a/_template/README.md
+++ b/_template/README.md
@@ -1,6 +1,6 @@
 # {{.Base.projectName}}
 
-[![GoTemplate](https://img.shields.io/badge/go/template-black?logo=go)](https://github.com/SchwarzIT/go-template) 
+[![GoTemplate](https://img.shields.io/badge/go/template-black?logo=go)](https://github.com/SchwarzIT/go-template)
 
 {{.Base.projectDescription}}
 


### PR DESCRIPTION
Remove space after badge in readme.

Signed-off-by: Steffen Exler <Steffen.Exler@mail.schwarz>