### PR TITLE
feat(deps): group all non major renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "group:allNonMajor",
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":gitSignOff"
@@ -8,9 +9,18 @@
   "dependencyDashboard": false,
   "packageRules": [
     {
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
     }
   ],
-  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ]
 }


### PR DESCRIPTION
Now that we also use renovate for the actions which are updated regularly we should use this to not flood the repo with PRs.