### PR TITLE
feat(template): Set ZAP loglevel via environment var

### DIFF
--- a/_template/cmd/{{.Base.appName}}/main.go
+++ b/_template/cmd/{{.Base.appName}}/main.go
@@ -19,10 +19,24 @@ func main() {
 }
 
 func getLogger() (*zap.Logger, error) {
-	if os.Getenv("LOG_LEVEL") == "debug" {
-		return zap.NewDevelopment()
+	logLevel := zapcore.InfoLevel
+	if levelStr := os.Getenv("LOG_LEVEL"); levelStr != "" {
+		var err error
+		logLevel, err = zapcore.ParseLevel(levelStr)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return zap.NewProduction()
+
+	logConf := zap.NewProductionConfig()
+	logConf.Level = zap.NewAtomicLevelAt(logLevel)
+
+	logger, err := logConf.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return logger, nil
 }
 
 func run() error {

--- a/_template/cmd/{{.Base.appName}}/main.go
+++ b/_template/cmd/{{.Base.appName}}/main.go
@@ -20,7 +20,7 @@ func main() {
 }
 
 func run() error {
-	logger, err := logger.GetLogger(os.Getenv("LOG_LEVEL"))
+	logger, err := logger.NewAtLevel(os.Getenv("LOG_LEVEL"))
 	if err != nil {
 		return err
 	}

--- a/_template/cmd/{{.Base.appName}}/main.go
+++ b/_template/cmd/{{.Base.appName}}/main.go
@@ -18,8 +18,15 @@ func main() {
 	}
 }
 
+func getLogger() (*zap.Logger, error) {
+	if os.Getenv("LOG_LEVEL") == "debug" {
+		return zap.NewDevelopment()
+	}
+	return zap.NewProduction()
+}
+
 func run() error {
-	logger, err := zap.NewProduction()
+	logger, err := getLogger()
 	if err != nil {
 		return err
 	}

--- a/_template/cmd/{{.Base.appName}}/main.go
+++ b/_template/cmd/{{.Base.appName}}/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"{{.Base.moduleName}}/internal/logger"
 	"go.uber.org/zap"
 
 	// This controls the maxprocs environment variable in container runtimes.
@@ -18,29 +19,8 @@ func main() {
 	}
 }
 
-func getLogger() (*zap.Logger, error) {
-	logLevel := zapcore.InfoLevel
-	if levelStr := os.Getenv("LOG_LEVEL"); levelStr != "" {
-		var err error
-		logLevel, err = zapcore.ParseLevel(levelStr)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	logConf := zap.NewProductionConfig()
-	logConf.Level = zap.NewAtomicLevelAt(logLevel)
-
-	logger, err := logConf.Build()
-	if err != nil {
-		return nil, err
-	}
-
-	return logger, nil
-}
-
 func run() error {
-	logger, err := getLogger()
+	logger, err := logger.GetLogger(os.Getenv("LOG_LEVEL"))
 	if err != nil {
 		return err
 	}

--- a/_template/internal/logger/logger.go
+++ b/_template/internal/logger/logger.go
@@ -5,9 +5,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func GetLogger(logLevelValue string) (*zap.Logger, error) {
+func NewAtLevel(levelStr string) (*zap.Logger, error) {
 	logLevel := zapcore.InfoLevel
-	if levelStr := logLevelValue; levelStr != "" {
+	if levelStr != "" {
 		var err error
 		logLevel, err = zapcore.ParseLevel(levelStr)
 		if err != nil {

--- a/_template/internal/logger/logger.go
+++ b/_template/internal/logger/logger.go
@@ -1,0 +1,27 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func GetLogger(logLevelValue string) (*zap.Logger, error) {
+	logLevel := zapcore.InfoLevel
+	if levelStr := logLevelValue; levelStr != "" {
+		var err error
+		logLevel, err = zapcore.ParseLevel(levelStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	logConf := zap.NewProductionConfig()
+	logConf.Level = zap.NewAtomicLevelAt(logLevel)
+
+	logger, err := logConf.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return logger, nil
+}


### PR DESCRIPTION
Set zap log level via environment var `LOG_LEVEL`. If `LOG_LEVEL` is `debug`, zap will be set to development and per default zap is set to production.

Signed-off-by: Steffen Exler <Steffen.Exler@mail.schwarz>