### PR TITLE
fix(ci): set correct release pipeline permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,8 @@ on:
     tags:
       - "*"
 
-permissions: read-all
+permissions:
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
Should fix release pipeline fails like https://github.com/SchwarzIT/go-template/actions/runs/2256549308

Also this seams to be the default according to docs:
https://goreleaser.com/ci/actions/