### PR TITLE
fix(ci): add content write permissions for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,14 +5,14 @@ on:
     tags:
       - "*"
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   release:
     permissions:
       id-token: write
       packages: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Since #111 didn't work, I forked the repo and checked the permissions again. Turns out I added the `contents: write` permissions globally which was then overwritten by the release steps `permissions`.

This now works on the fork, so this should fix the pipeline.