### PR TITLE
feat: add flake.nix file to consume gt via nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ run: fmt ## Run a controller from your host
 generate: ## Generates files
 	@go run cmd/dotembed/main.go -target _template -o embed_gen.go -pkg gotemplate -var FS
 	@go run cmd/options2md/main.go -o docs/options.md
+	@go run github.com/nix-community/gomod2nix@latest --outdir nix
 
 GOLANGCI_LINT = bin/golangci-lint-$(GOLANGCI_VERSION)
 $(GOLANGCI_LINT):

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ go install github.com/schwarzit/go-template/cmd/gt@latest
 Download the desired version for your operating system and processor architecture from the [go-template releases page](https://github.com/SchwarzIT/go-template/releases).
 Make the file executable and place it in a directory available in your `$PATH`.
 
+#### nix
+
+`go-template` also provides a [flake.nix](flake.nix) to install it via [nix package manager](https://github.com/NixOS/nix).
+
+You can also try out `go-template` without installing:
+
+```shell
+nix run github:schwarzit/go-template
+```
+
 ### Preconditions
 
 `go/template`'s `gt` CLI requires at least the following executables on `$PATH` to run succesfully:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,93 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1662501203,
+        "narHash": "sha256-4BKeqCX2zwgBiTdlc2DjGQ0CttKm0vSw0r/bdFdM/PQ=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "89cd0675b96775aa3ee86e7c0cf5bc238dd27976",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658285632,
+        "narHash": "sha256-zRS5S/hoeDGUbO+L95wXG9vJNwsSYcl93XiD0HQBXLk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5342fc6fb59d0595d26883c3cadff16ce58e44f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1665238359,
+        "narHash": "sha256-XEiayS3ojjKc47bgHDf9Qcry9lFR7jPHtq32ClXa1zA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1302a0089e221b8240ba7feb1be87c05fcbc70ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    gomod2nix.url = "github:nix-community/gomod2nix";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, gomod2nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        name = "go-template";
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ gomod2nix.overlays.default ];
+        };
+      in
+      rec {
+        packages = {
+          default = packages.${name};
+          ${name} = pkgs.buildGoApplication {
+            pname = name;
+            version = pkgs.lib.removeSuffix "\n" (builtins.readFile ./config/version.txt);
+            src = ./.;
+            modules = ./nix/gomod2nix.toml;
+            subPackages = [ "cmd/gt" ];
+            ldflags = [ "-s" "-w" ];
+            meta = with pkgs.lib; {
+              description = "go/template is a tool for jumpstarting production-ready Golang projects quickly.";
+              homepage = "https://github.com/schwarzit/go-template";
+              maintainers = with maintainers; [ brumhard ];
+              license = licenses.asl20; # Apache License 2.0
+            };
+          };
+        };
+
+        apps = {
+          default = flake-utils.lib.mkApp {
+            drv = packages.default;
+            exePath = "/bin/gt";
+          };
+        };
+      });
+}

--- a/nix/gomod2nix.toml
+++ b/nix/gomod2nix.toml
@@ -1,0 +1,78 @@
+schema = 3
+
+[mod]
+  [mod."github.com/Masterminds/goutils"]
+    version = "v1.1.1"
+    hash = "sha256-MEvA5e099GUllILa5EXxa6toQexU1sz6eDZt2tiqpCY="
+  [mod."github.com/Masterminds/semver/v3"]
+    version = "v3.1.1"
+    hash = "sha256-6AbVa1URv04zlxUZA/Wc484EzrzgAuPcuub3WFBRWDc="
+  [mod."github.com/Masterminds/sprig/v3"]
+    version = "v3.2.2"
+    hash = "sha256-XXDG2ImEqg+TbrXBNYAXaqeV0H/nsNRfijqctCv8y3E="
+  [mod."github.com/davecgh/go-spew"]
+    version = "v1.1.1"
+    hash = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI="
+  [mod."github.com/fatih/color"]
+    version = "v1.13.0"
+    hash = "sha256-Xo0zFKLm/9NuChdHDhHoUFo8Oa7Mkb3ezZCu23SfOAk="
+  [mod."github.com/google/go-github/v39"]
+    version = "v39.2.0"
+    hash = "sha256-rzMQo5Cnmky9zehUDaGrG2nL25hAd55jJe/efay04CM="
+  [mod."github.com/google/go-querystring"]
+    version = "v1.1.0"
+    hash = "sha256-itsKgKghuX26czU79cK6C2n+lc27jm5Dw1XbIRgwZJY="
+  [mod."github.com/google/uuid"]
+    version = "v1.3.0"
+    hash = "sha256-QoR55eBtA94T2tBszyxfDtO7/pjZZSGb5vm7U0Xhs0Y="
+  [mod."github.com/huandu/xstrings"]
+    version = "v1.3.2"
+    hash = "sha256-ueAZrYRXMdRpeTKct3Yxa5YXkCZEoUHpNQs7wLLJil8="
+  [mod."github.com/imdario/mergo"]
+    version = "v0.3.12"
+    hash = "sha256-IPGunEznxlUilS22LUU4p/QTA7f5+Goowf1Utg9ARpc="
+  [mod."github.com/inconshreveable/mousetrap"]
+    version = "v1.0.0"
+    hash = "sha256-ogTuLrV40FwS4ueo4hh6hi1wPywOI+LyIqfNjsibwNY="
+  [mod."github.com/mattn/go-colorable"]
+    version = "v0.1.12"
+    hash = "sha256-Y1vCt0ShrCz4wSmwsppCfeLPLKrWusc2zM2lUFwDMyI="
+  [mod."github.com/mattn/go-isatty"]
+    version = "v0.0.14"
+    hash = "sha256-e8zn5eCVh/B1HOP1PGXeXH0bGkIV0vKYP9KLwZni5as="
+  [mod."github.com/mitchellh/copystructure"]
+    version = "v1.2.0"
+    hash = "sha256-VR9cPZvyW62IHXgmMw8ee+hBDThzd2vftgPksQYR/Mc="
+  [mod."github.com/mitchellh/reflectwalk"]
+    version = "v1.0.2"
+    hash = "sha256-VX9DPqChm7jPnyrA3RAYgxAFrAhj7TRKIWD/qR9Zr9s="
+  [mod."github.com/pkg/errors"]
+    version = "v0.9.1"
+    hash = "sha256-mNfQtcrQmu3sNg/7IwiieKWOgFQOVVe2yXgKBpe/wZw="
+  [mod."github.com/pmezard/go-difflib"]
+    version = "v1.0.0"
+    hash = "sha256-/FtmHnaGjdvEIKAJtrUfEhV7EVo5A/eYrtdnUkuxLDA="
+  [mod."github.com/shopspring/decimal"]
+    version = "v1.2.0"
+    hash = "sha256-f4Sk7p3S4ClpJN9sfm5MOJhWftcXrGgpX2ArRLt8TBg="
+  [mod."github.com/spf13/cast"]
+    version = "v1.4.1"
+    hash = "sha256-jaY+/RKUviKnE2h8Ly5cdZYinSE0uc32FW6+xfZ1Ghs="
+  [mod."github.com/spf13/cobra"]
+    version = "v1.5.0"
+    hash = "sha256-rcyHWrxshA5DVpxrSba5X4NjppqOGrJ64QkUKKnfW2E="
+  [mod."github.com/spf13/pflag"]
+    version = "v1.0.5"
+    hash = "sha256-w9LLYzxxP74WHT4ouBspH/iQZXjuAh2WQCHsuvyEjAw="
+  [mod."github.com/stretchr/testify"]
+    version = "v1.8.0"
+    hash = "sha256-LDxBAebK+A06y4vbH7cd1sVBOameIY81Xm8/9OPZh7o="
+  [mod."golang.org/x/crypto"]
+    version = "v0.0.0-20210915214749-c084706c2272"
+    hash = "sha256-xJkNphIlSfFUXryOK1Tom9GQIZrOzoG7Qq6ScKxV70Q="
+  [mod."golang.org/x/sys"]
+    version = "v0.0.0-20211205182925-97ca703d548d"
+    hash = "sha256-hGalTJfPEB6kjkKTTnPLPpsZ/L+meujDHlm54bIP9qE="
+  [mod."gopkg.in/yaml.v3"]
+    version = "v3.0.1"
+    hash = "sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU="


### PR DESCRIPTION
This PR adds a flake.nix file which is used to install go-template within the nix ecosystem.
In the future this could also be used to provide dev environments for developers.