### PR TITLE
fix(ci): pin goreleaser version to v1.10.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,9 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757 # tag=v3.2.0
         with:
-          version: latest
+          # TODO(brumhard): set back to latest after issue is fixed
+          # https://github.com/goreleaser/goreleaser/issues/3573
+          version: v1.10.3
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Temporarily treats #179 until https://github.com/goreleaser/goreleaser/issues/3573 is fixed.
That enables the creation of new releases until the bug fix.
The used version is the last working version from https://github.com/SchwarzIT/go-template/actions/runs/2924879055