### PR TITLE
fix(ci): git push new tag in tag_release

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -13,20 +13,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        # using a PAT is necessary to trigger the release workflow
+        # see https://github.com/orgs/community/discussions/25702
         with:
-          fetch-depth: 0
-      - name: Get current version from file
+          token: ${{ secrets.PAT }}
+      - name: Get version from file
         id: tag
         run: |
           export VERSION="$(cat config/version.txt)"
-          echo "tag=$VERSION" >> $GITHUB_OUTPUT
-      - name: Create tag
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # tag=v6.3.3
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: "refs/tags/v${{ steps.tag.outputs.tag }}",
-              sha: context.sha
-            })
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+      - name: Check tag is new
+        run: |
+          git fetch origin --tags
+          if git tag |grep -qE ^"${{ steps.tag.outputs.tag }}"$; then
+            echo "tag already exists"
+            exit 1
+          fi
+      - name: Create and push tag
+        run: |
+          git tag ${{ steps.tag.outputs.tag }}
+          git push --tags


### PR DESCRIPTION
Fixes #178 
Turns out that actions won't trigger other actions unless a PAT is used (see https://github.com/orgs/community/discussions/25702).
Therefore, it will be necessary that @patrick246 creates a PAT secret for that repo that the workflow can use.