### PR TITLE
fix(engine): Remove Codeowners when no OpenSource project

### DIFF
--- a/pkg/gotemplate/options.go
+++ b/pkg/gotemplate/options.go
@@ -270,6 +270,10 @@ Options:
 	8: The Unlicense`,
 						postHook: func(v interface{}, _ *OptionValues, targetDir string) error {
 							if v.(int) == 0 {
+								err := os.RemoveAll(path.Join(targetDir, "CODEOWNERS"))
+								if err != nil {
+									return err
+								}
 								return os.RemoveAll(path.Join(targetDir, "LICENSE"))
 							}
 							return nil

--- a/pkg/gotemplate/options.go
+++ b/pkg/gotemplate/options.go
@@ -270,11 +270,12 @@ Options:
 	8: The Unlicense`,
 						postHook: func(v interface{}, _ *OptionValues, targetDir string) error {
 							if v.(int) == 0 {
-								err := os.RemoveAll(path.Join(targetDir, "CODEOWNERS"))
-								if err != nil {
-									return err
+								files := []string{"LICENSE", "CODEOWNERS"}
+								for _, file := range files {
+									if err := os.RemoveAll(path.Join(targetDir, file)); err != nil {
+										return err
+									}
 								}
-								return os.RemoveAll(path.Join(targetDir, "LICENSE"))
 							}
 							return nil
 						},
@@ -311,6 +312,12 @@ Options:
 							return strings.TrimSpace(buffer.String())
 						}),
 						description: "Set the codeowner of the project",
+						shouldDisplay: DynamicBoolValue(func(vals *OptionValues) bool {
+							if vals.Extensions["openSource"]["license"].(int) == 0 { //nolint:gomnd // 0: no license
+								return false
+							}
+							return true
+						}),
 					},
 				},
 			},

--- a/pkg/gotemplate/options.go
+++ b/pkg/gotemplate/options.go
@@ -313,10 +313,7 @@ Options:
 						}),
 						description: "Set the codeowner of the project",
 						shouldDisplay: DynamicBoolValue(func(vals *OptionValues) bool {
-							if vals.Extensions["openSource"]["license"].(int) == 0 { //nolint:gomnd // 0: no license
-								return false
-							}
-							return true
+							return vals.Extensions["openSource"]["license"].(int) != 0 // 0 == no license
 						}),
 					},
 				},


### PR DESCRIPTION
Remove Codeowners when no OpenSource license is selected.
Fix: #152