### PR TITLE
feat: update codeowners to use github handles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* tobias.brumhard@mail.schwarz steffen.exler@mail.schwarz daniel.zwink@mail.schwarz
+* @brumhard @linuxluigi @danielzwink


### PR DESCRIPTION
The emails we used in the codeowners are outdated so I thought it would be better to use the github handles since I guess they won't change as much.