### PR TITLE
feat(ci): add make generate to renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,5 +22,16 @@
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "make generate"
+    ],
+    // only include updates to the following files in the PR
+    "fileFilters": [
+      "nix/gomod2nix.toml"
+    ],
+    // only run once per update branch
+    "executionMode": "branch"
+  }
 }


### PR DESCRIPTION
Not sure if this is the right approach or whether we should just use https://github.com/SchwarzIT/go-template/pull/213 and set https://docs.renovatebot.com/configuration-options/#gitignoredauthors.