### PR TITLE
fix(ci): trigger push on generated files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
           git commit -m "chore: regenerate files"
 
       - name: Push changes
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: steps.verify-changed-files-coverage.outputs.files_changed == 'true' || steps.verify-changed-files-generate.outputs.files_changed == 'true'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
E.g. in this CI run https://github.com/SchwarzIT/go-template/actions/runs/4704835624/jobs/8344803718 I saw that push was skipped because the condition for the push was not correct.
This should fix that.