### PR TITLE
fix(template): remove depguard linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: "^1.20"
+          go-version: "^1.20.6"
 
       - name: Checkout code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: 1.20.x
+          go-version: "^1.20"
 
       - name: Checkout code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,7 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/
   enable:
-    - cyclop # Go linter that checks if package imports are in a list of acceptable packages
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
+    - cyclop # Go linter that checks if the cyclic complexity of a function is acceptable
     - dogsled # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - dupl # Tool for code clone detection
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.

--- a/_template/.golangci.yml
+++ b/_template/.golangci.yml
@@ -7,8 +7,7 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/
   enable:
-    - cyclop # Go linter that checks if package imports are in a list of acceptable packages
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
+    - cyclop # Go linter that checks if the cyclic complexity of a function is acceptable
     - dogsled # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - dupl # Tool for code clone detection
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.

--- a/nix/gomod2nix.toml
+++ b/nix/gomod2nix.toml
@@ -551,8 +551,8 @@ schema = 3
     version = "v0.7.0"
     hash = "sha256-ZEjfFulQd6U9r4mEJ5RZOnW49NZnQnrCFLMKCgLg7go="
   [mod."golang.org/x/vuln"]
-    version = "v0.0.0-20230413193909-03dd099d9b0d"
-    hash = "sha256-VBndCbBi2ffzdlr9kigG2WhhzGBs7CionvxEbjz58ws="
+    version = "v0.0.0-20230414205624-d3666e3e8dbb"
+    hash = "sha256-vKEON5xlVBVBof9wbvc2tppcWCCLeH5e9Zs0hHmB0/I="
   [mod."google.golang.org/appengine"]
     version = "v1.6.7"
     hash = "sha256-zIxGRHiq4QBvRqkrhMGMGCaVL4iM4TtlYpAi/hrivS4="


### PR DESCRIPTION
The new standard config for the depguard linter since golangci-lint 1.53 allows only the standard library in all files. As depguard is not further configured, we can just remove it and get the old behavior back