### PR TITLE
fix(ci): remove govulncheck from main pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,10 +81,6 @@ jobs:
           git add README.md
           git commit -m "chore(docs): update coverage badge"
 
-      - name: Run Vulnerability detection using govulncheck
-        if: matrix.os == 'ubuntu-latest'
-        run: make govulncheck
-
       - name: Build package
         run: make build
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ generate: ## Generates files
 lint: fmt download ## Lints all code with golangci-lint
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run
 
-
 govulncheck: ## Vulnerability detection using govulncheck
 	@go run golang.org/x/vuln/cmd/govulncheck ./...
 


### PR DESCRIPTION
Currently, all the pipelines fail due to a vulnerability detected by govulncheck which is only fixed in go1.21 which is not yet released.
There's no way to ignore vulns in govulncheck sadly.
Since this is a CLI and also we're using all the latest versions from renovatebot, the report doesn't really have much value since there's nothign we can really do about it